### PR TITLE
Create CRUD on Submission Model

### DIFF
--- a/app/Api/V1/Controllers/ProblemController.php
+++ b/app/Api/V1/Controllers/ProblemController.php
@@ -91,7 +91,7 @@ class ProblemController extends BaseController
         $params->fromArray($fields);
 
         $service->update($id,$params);
-        return $this->response->created();
+        return $this->response->noContent();
     }
 
     public function delete(
@@ -101,6 +101,6 @@ class ProblemController extends BaseController
     {
         $this->checkRole('problem-setter');
         $service->delete($id);
-        return $this->response->created();
+        return $this->response->noContent();
     }
 }

--- a/app/Api/V1/Controllers/ProblemController.php
+++ b/app/Api/V1/Controllers/ProblemController.php
@@ -5,8 +5,11 @@ namespace App\Api\V1\Controllers;
 
 use App\Api\V1\Domain\Problem\Param\CreateProblemParam;
 use App\Api\V1\Domain\Problem\Param\ReadProblemParam;
+use App\Api\V1\Domain\Problem\Param\UpdateProblemParam;
 use App\Api\V1\Domain\Problem\Services\CreateProblemService;
+use App\Api\V1\Domain\Problem\Services\DeleteProblemService;
 use App\Api\V1\Domain\Problem\Services\ReadProblemService;
+use App\Api\V1\Domain\Problem\Services\UpdateProblemService;
 use App\Api\V1\Domain\Problem\Transformer\ProblemTransformer;
 use App\Api\V1\Domain\User\Entity\User;
 use Dingo\Api\Http\Response;
@@ -16,6 +19,10 @@ class ProblemController extends BaseController
 {
     const QUERY_LIMIT = 'limit';
     const DEFAULT_LIMIT = 10;
+
+    const QUERY_FROM = 'from';
+    const FROM_STATEMENT = 'statement';
+    const FROM_GRADING = 'grading';
 
     public function store(
         CreateProblemService $service,
@@ -65,5 +72,35 @@ class ProblemController extends BaseController
     {
         $problem = $service->readSingle($id);
         return $this->response->item($problem, $problemTransformer);
+    }
+
+    public function update(
+        UpdateProblemService $service,
+        Request $request,
+        int $id
+    ): Response
+    {
+        $this->checkRole('problem-setter');
+        $sourcePost = $request->get(self::QUERY_FROM);
+        $fields = $request->only(UpdateProblemParam::QUERY_PARAMS[$sourcePost]);
+
+        $validation = $this->getValidationFactory()->make($fields,UpdateProblemParam::QUERY_PARAM_VALIDATION[$sourcePost]);
+        $this->checkValidation($validation);
+
+        $params = new UpdateProblemParam($id);
+        $params->fromArray($fields);
+
+        $service->update($id,$params);
+        return $this->response->created();
+    }
+
+    public function delete(
+        DeleteProblemService $service,
+        int $id
+    ): Response
+    {
+        $this->checkRole('problem-setter');
+        $service->delete($id);
+        return $this->response->created();
     }
 }

--- a/app/Api/V1/Controllers/ProblemController.php
+++ b/app/Api/V1/Controllers/ProblemController.php
@@ -21,8 +21,6 @@ class ProblemController extends BaseController
     const DEFAULT_LIMIT = 10;
 
     const QUERY_FROM = 'from';
-    const FROM_STATEMENT = 'statement';
-    const FROM_GRADING = 'grading';
 
     public function store(
         CreateProblemService $service,

--- a/app/Api/V1/Controllers/ProblemController.php
+++ b/app/Api/V1/Controllers/ProblemController.php
@@ -20,8 +20,6 @@ class ProblemController extends BaseController
     const QUERY_LIMIT = 'limit';
     const DEFAULT_LIMIT = 10;
 
-    const QUERY_FROM = 'from';
-
     public function store(
         CreateProblemService $service,
         Request $request
@@ -79,10 +77,9 @@ class ProblemController extends BaseController
     ): Response
     {
         $this->checkRole('problem-setter');
-        $sourcePost = $request->get(self::QUERY_FROM);
-        $fields = $request->only(UpdateProblemParam::QUERY_PARAMS[$sourcePost]);
+        $fields = $request->only(UpdateProblemParam::QUERY_PARAMS);
 
-        $validation = $this->getValidationFactory()->make($fields,UpdateProblemParam::QUERY_PARAM_VALIDATION[$sourcePost]);
+        $validation = $this->getValidationFactory()->make($fields,UpdateProblemParam::QUERY_PARAM_VALIDATION);
         $this->checkValidation($validation);
 
         $params = new UpdateProblemParam($id);

--- a/app/Api/V1/Controllers/SubmissionController.php
+++ b/app/Api/V1/Controllers/SubmissionController.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: ferdinand
- * Date: 8/25/18
- * Time: 11:47 AM
- */
 
 namespace App\Api\V1\Controllers;
 

--- a/app/Api/V1/Controllers/SubmissionController.php
+++ b/app/Api/V1/Controllers/SubmissionController.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ferdinand
+ * Date: 8/25/18
+ * Time: 11:47 AM
+ */
+
+namespace App\Api\V1\Controllers;
+
+
+use App\Api\V1\Domain\Submission\Param\CreateSubmissionParam;
+use App\Api\V1\Domain\Submission\Services\CreateSubmissionService;
+use Dingo\Api\Http\Response;
+use Illuminate\Http\Request;
+
+class SubmissionController extends BaseController
+{
+    public function store(
+        CreateSubmissionService $service,
+        Request $request
+    ): Response
+    {
+        $fields = $request->only(CreateSubmissionParam::QUERY_PARAMS);
+
+        $validation = $this->getValidationFactory()->make($fields, CreateSubmissionParam::QUERY_PARAMS_VALIDATION);
+        $this->checkValidation($validation);
+
+        $params = new CreateSubmissionParam();
+        $params->fromArray($fields);
+
+        $service->createOne($params);
+        return $this->response->created();
+    }
+}

--- a/app/Api/V1/Domain/Problem/Entity/Problem.php
+++ b/app/Api/V1/Domain/Problem/Entity/Problem.php
@@ -27,6 +27,7 @@ class Problem extends Model
         self::ATTRIBUTE_MEMORY_LIMIT,
         self::ATTRIBUTE_TIME_LIMIT,
         self::ATTRIBUTE_OWNER_ID,
+        self::ATTRIBUTE_IS_PUBLIC,
     ];
 
     public function owner(): BelongsTo

--- a/app/Api/V1/Domain/Problem/Entity/Problem.php
+++ b/app/Api/V1/Domain/Problem/Entity/Problem.php
@@ -15,6 +15,7 @@ class Problem extends Model
     const ATTRIBUTE_DESCRIPTION = 'description';
     const ATTRIBUTE_MEMORY_LIMIT = 'memory_limit';
     const ATTRIBUTE_TIME_LIMIT = 'time_limit';
+    const ATTRIBUTE_IS_PUBLIC = 'is_public';
 
     const DEFAULT_MEMORY_LIMIT = 64;
     const DEFAULT_TIME_LIMIT = 1000;

--- a/app/Api/V1/Domain/Problem/Param/CreateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/CreateProblemParam.php
@@ -46,7 +46,9 @@ class CreateProblemParam
         $this->data[Problem::ATTRIBUTE_SLUG] = $array[Problem::ATTRIBUTE_SLUG];
         $this->data[Problem::ATTRIBUTE_TITLE] = $array[Problem::ATTRIBUTE_TITLE];
         $this->data[Problem::ATTRIBUTE_DESCRIPTION] = $array[Problem::ATTRIBUTE_DESCRIPTION];
-        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = $array[Problem::ATTRIBUTE_IS_PUBLIC];
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = isset($array[Problem::ATTRIBUTE_IS_PUBLIC])
+            ? $array[Problem::ATTRIBUTE_IS_PUBLIC]
+            : null;
         $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = isset($array[Problem::ATTRIBUTE_MEMORY_LIMIT])
             ? $array[Problem::ATTRIBUTE_MEMORY_LIMIT]
             : Problem::DEFAULT_MEMORY_LIMIT;

--- a/app/Api/V1/Domain/Problem/Param/CreateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/CreateProblemParam.php
@@ -12,6 +12,7 @@ class CreateProblemParam
         Problem::ATTRIBUTE_DESCRIPTION,
         Problem::ATTRIBUTE_MEMORY_LIMIT,
         Problem::ATTRIBUTE_TIME_LIMIT,
+        Problem::ATTRIBUTE_IS_PUBLIC,
     ];
 
     const QUERY_PARAM_VALIDATION = [
@@ -24,6 +25,7 @@ class CreateProblemParam
         Problem::ATTRIBUTE_DESCRIPTION => 'string|required',
         Problem::ATTRIBUTE_MEMORY_LIMIT => 'numeric|nullable|between:0,255',
         Problem::ATTRIBUTE_TIME_LIMIT => 'numeric|nullable|between:0,10000',
+        Problem::ATTRIBUTE_IS_PUBLIC => 'boolean|required',
     ];
 
     protected $data = [];
@@ -36,6 +38,7 @@ class CreateProblemParam
         $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = null;
         $this->data[Problem::ATTRIBUTE_TIME_LIMIT] = null;
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = null;
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = null;
     }
 
     public function fromArray(array $array): void
@@ -43,6 +46,7 @@ class CreateProblemParam
         $this->data[Problem::ATTRIBUTE_SLUG] = $array[Problem::ATTRIBUTE_SLUG];
         $this->data[Problem::ATTRIBUTE_TITLE] = $array[Problem::ATTRIBUTE_TITLE];
         $this->data[Problem::ATTRIBUTE_DESCRIPTION] = $array[Problem::ATTRIBUTE_DESCRIPTION];
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = $array[Problem::ATTRIBUTE_IS_PUBLIC];
         $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = isset($array[Problem::ATTRIBUTE_MEMORY_LIMIT])
             ? $array[Problem::ATTRIBUTE_MEMORY_LIMIT]
             : Problem::DEFAULT_MEMORY_LIMIT;

--- a/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
@@ -14,7 +14,7 @@ class ReadProblemParam
 
     const QUERY_PARAMS_VALIDATION = [
         Problem::ATTRIBUTE_OWNER_ID => 'numeric|nullable',
-        Problem::ATTRIBUTE_IS_PUBLIC => 'string|nullable',
+        Problem::ATTRIBUTE_IS_PUBLIC => 'boolean|nullable',
     ];
 
     protected $data = [];

--- a/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
@@ -14,7 +14,7 @@ class ReadProblemParam
 
     const QUERY_PARAMS_VALIDATION = [
         Problem::ATTRIBUTE_OWNER_ID => 'numeric|nullable',
-        Problem::ATTRIBUTE_IS_PUBLIC => 'boolean|nullable',
+        Problem::ATTRIBUTE_IS_PUBLIC => 'string|nullable',
     ];
 
     protected $data = [];
@@ -36,7 +36,7 @@ class ReadProblemParam
         return $this->data[Problem::ATTRIBUTE_OWNER_ID];
     }
 
-    public function getIsPublic(): ?int
+    public function getIsPublic(): ?bool
     {
         return $this->data[Problem::ATTRIBUTE_IS_PUBLIC];
     }

--- a/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
@@ -9,10 +9,12 @@ class ReadProblemParam
 {
     const QUERY_PARAMS = [
         Problem::ATTRIBUTE_OWNER_ID,
+        Problem::ATTRIBUTE_IS_PUBLIC,
     ];
 
     const QUERY_PARAMS_VALIDATION = [
         Problem::ATTRIBUTE_OWNER_ID => 'numeric|nullable',
+        Problem::ATTRIBUTE_IS_PUBLIC => 'boolean|nullable',
     ];
 
     protected $data = [];
@@ -20,15 +22,22 @@ class ReadProblemParam
     public function __construct()
     {
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = null;
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = null;
     }
 
     public function fromArray(array $array): void
     {
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = $array[Problem::ATTRIBUTE_OWNER_ID];
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = $array[Problem::ATTRIBUTE_IS_PUBLIC];
     }
 
     public function getOwnerId(): ?int
     {
         return $this->data[Problem::ATTRIBUTE_OWNER_ID];
+    }
+
+    public function getIsPublic(): ?int
+    {
+        return $this->data[Problem::ATTRIBUTE_IS_PUBLIC];
     }
 }

--- a/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/ReadProblemParam.php
@@ -3,32 +3,32 @@
 namespace App\Api\V1\Domain\Problem\Param;
 
 
+use App\Api\V1\Domain\Problem\Entity\Problem;
+
 class ReadProblemParam
 {
-    const ATTRIBUTE_OWNER_ID = 'owner_id';
-
     const QUERY_PARAMS = [
-        ReadProblemParam::ATTRIBUTE_OWNER_ID,
+        Problem::ATTRIBUTE_OWNER_ID,
     ];
 
     const QUERY_PARAMS_VALIDATION = [
-        ReadProblemParam::ATTRIBUTE_OWNER_ID => 'numeric|nullable',
+        Problem::ATTRIBUTE_OWNER_ID => 'numeric|nullable',
     ];
 
     protected $data = [];
 
     public function __construct()
     {
-        $this->data[ReadProblemParam::ATTRIBUTE_OWNER_ID] = null;
+        $this->data[Problem::ATTRIBUTE_OWNER_ID] = null;
     }
 
     public function fromArray(array $array): void
     {
-        $this->data[ReadProblemParam::ATTRIBUTE_OWNER_ID] = $array[ReadProblemParam::ATTRIBUTE_OWNER_ID];
+        $this->data[Problem::ATTRIBUTE_OWNER_ID] = $array[Problem::ATTRIBUTE_OWNER_ID];
     }
 
     public function getOwnerId(): ?int
     {
-        return $this->data[ReadProblemParam::ATTRIBUTE_OWNER_ID];
+        return $this->data[Problem::ATTRIBUTE_OWNER_ID];
     }
 }

--- a/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
@@ -1,0 +1,79 @@
+<?php
+namespace App\Api\V1\Domain\Problem\Param;
+
+
+use App\Api\V1\Domain\Problem\Entity\Problem;
+
+class UpdateProblemParam
+{
+    const FROM_STATEMENT = 'statement';
+    const FROM_GRADING = 'grading';
+
+    const QUERY_PARAMS = [
+        UpdateProblemParam::FROM_STATEMENT => [
+            Problem::ATTRIBUTE_SLUG,
+            Problem::ATTRIBUTE_TITLE,
+            Problem::ATTRIBUTE_DESCRIPTION,
+        ],
+        UpdateProblemParam::FROM_GRADING => [
+            Problem::ATTRIBUTE_MEMORY_LIMIT,
+            Problem::ATTRIBUTE_TIME_LIMIT,
+        ],
+    ];
+
+    const QUERY_PARAM_VALIDATION = [
+        UpdateProblemParam::FROM_STATEMENT => [
+            Problem::ATTRIBUTE_SLUG => [
+                'required',
+                'regex:/^[A-Z0-9]+(?:-[A-Z0-9]+)*$/',
+            ],
+            Problem::ATTRIBUTE_TITLE => 'string|required',
+            Problem::ATTRIBUTE_DESCRIPTION => 'string|required',
+        ],
+        UpdateProblemParam::FROM_GRADING => [
+            Problem::ATTRIBUTE_MEMORY_LIMIT => 'numeric|between:0,255|required',
+            Problem::ATTRIBUTE_TIME_LIMIT => 'numeric|between:0,10000|required',
+        ],
+    ];
+
+    protected $data = [];
+    protected $problem = null;
+
+    public function __construct(int $id)
+    {
+        $this->problem = Problem::find($id);
+        $this->data[Problem::ATTRIBUTE_SLUG] = null;
+        $this->data[Problem::ATTRIBUTE_TITLE] = null;
+        $this->data[Problem::ATTRIBUTE_DESCRIPTION] = null;
+        $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = null;
+        $this->data[Problem::ATTRIBUTE_TIME_LIMIT] = null;
+        $this->data[Problem::ATTRIBUTE_OWNER_ID] = null;
+    }
+
+    public function fromArray(array $array): void
+    {
+        $this->data[Problem::ATTRIBUTE_SLUG] = isset($array[Problem::ATTRIBUTE_SLUG])
+            ? $array[Problem::ATTRIBUTE_SLUG]
+            : $this->problem->slug;
+        $this->data[Problem::ATTRIBUTE_TITLE] = isset($array[Problem::ATTRIBUTE_TITLE])
+            ?$array[Problem::ATTRIBUTE_TITLE]
+            : $this->problem->title;
+        $this->data[Problem::ATTRIBUTE_DESCRIPTION] = isset($array[Problem::ATTRIBUTE_DESCRIPTION])
+            ? $array[Problem::ATTRIBUTE_DESCRIPTION]
+            : $this->problem->description;
+        $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = isset($array[Problem::ATTRIBUTE_MEMORY_LIMIT])
+            ? $array[Problem::ATTRIBUTE_MEMORY_LIMIT]
+            : $this->problem->memoty_limit;
+        $this->data[Problem::ATTRIBUTE_TIME_LIMIT] = isset($array[Problem::ATTRIBUTE_TIME_LIMIT])
+            ? $array[Problem::ATTRIBUTE_TIME_LIMIT]
+            : $this->problem->time_limit;
+        $this->data[Problem::ATTRIBUTE_OWNER_ID] = isset($array[Problem::ATTRIBUTE_OWNER_ID])
+            ? $array[Problem::ATTRIBUTE_OWNER_ID]
+            : $this->problem->owner_id;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
@@ -63,7 +63,7 @@ class UpdateProblemParam
     {
         $array = [];
         foreach (self::QUERY_PARAMS as $param){
-            if(isset($this->data[$param])){
+            if($this->data[$param] !== null){
                 $array[] = $this->data[$param];
             }
         }

--- a/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
@@ -64,7 +64,7 @@ class UpdateProblemParam
         $array = [];
         foreach (self::QUERY_PARAMS as $param){
             if($this->data[$param] !== null){
-                $array[] = $this->data[$param];
+                $array[$param] = $this->data[$param];
             }
         }
         return $array;

--- a/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Api\V1\Domain\Problem\Param;
 
 
@@ -12,6 +13,7 @@ class UpdateProblemParam
         Problem::ATTRIBUTE_DESCRIPTION,
         Problem::ATTRIBUTE_MEMORY_LIMIT,
         Problem::ATTRIBUTE_TIME_LIMIT,
+        Problem::ATTRIBUTE_IS_PUBLIC,
     ];
 
     const QUERY_PARAM_VALIDATION = [
@@ -23,6 +25,7 @@ class UpdateProblemParam
         Problem::ATTRIBUTE_DESCRIPTION => 'string|nullable',
         Problem::ATTRIBUTE_MEMORY_LIMIT => 'numeric|between:0,255|nullable',
         Problem::ATTRIBUTE_TIME_LIMIT => 'numeric|between:0,10000|nullable',
+        Problem::ATTRIBUTE_IS_PUBLIC => 'boolean|nullable',
     ];
 
     protected $data = [];
@@ -35,6 +38,7 @@ class UpdateProblemParam
         $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = null;
         $this->data[Problem::ATTRIBUTE_TIME_LIMIT] = null;
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = null;
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = null;
     }
 
     public function fromArray(array $array): void
@@ -43,7 +47,7 @@ class UpdateProblemParam
             ? $array[Problem::ATTRIBUTE_SLUG]
             : null;
         $this->data[Problem::ATTRIBUTE_TITLE] = isset($array[Problem::ATTRIBUTE_TITLE])
-            ?$array[Problem::ATTRIBUTE_TITLE]
+            ? $array[Problem::ATTRIBUTE_TITLE]
             : null;
         $this->data[Problem::ATTRIBUTE_DESCRIPTION] = isset($array[Problem::ATTRIBUTE_DESCRIPTION])
             ? $array[Problem::ATTRIBUTE_DESCRIPTION]
@@ -57,13 +61,16 @@ class UpdateProblemParam
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = isset($array[Problem::ATTRIBUTE_OWNER_ID])
             ? $array[Problem::ATTRIBUTE_OWNER_ID]
             : null;
+        $this->data[Problem::ATTRIBUTE_IS_PUBLIC] = isset($array[Problem::ATTRIBUTE_IS_PUBLIC])
+            ? $array[Problem::ATTRIBUTE_IS_PUBLIC]
+            : null;
     }
 
     public function toArray(): array
     {
         $array = [];
-        foreach (self::QUERY_PARAMS as $param){
-            if($this->data[$param] !== null){
+        foreach (self::QUERY_PARAMS as $param) {
+            if ($this->data[$param] !== null) {
                 $array[$param] = $this->data[$param];
             }
         }

--- a/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
+++ b/app/Api/V1/Domain/Problem/Param/UpdateProblemParam.php
@@ -6,42 +6,29 @@ use App\Api\V1\Domain\Problem\Entity\Problem;
 
 class UpdateProblemParam
 {
-    const FROM_STATEMENT = 'statement';
-    const FROM_GRADING = 'grading';
-
     const QUERY_PARAMS = [
-        UpdateProblemParam::FROM_STATEMENT => [
-            Problem::ATTRIBUTE_SLUG,
-            Problem::ATTRIBUTE_TITLE,
-            Problem::ATTRIBUTE_DESCRIPTION,
-        ],
-        UpdateProblemParam::FROM_GRADING => [
-            Problem::ATTRIBUTE_MEMORY_LIMIT,
-            Problem::ATTRIBUTE_TIME_LIMIT,
-        ],
+        Problem::ATTRIBUTE_SLUG,
+        Problem::ATTRIBUTE_TITLE,
+        Problem::ATTRIBUTE_DESCRIPTION,
+        Problem::ATTRIBUTE_MEMORY_LIMIT,
+        Problem::ATTRIBUTE_TIME_LIMIT,
     ];
 
     const QUERY_PARAM_VALIDATION = [
-        UpdateProblemParam::FROM_STATEMENT => [
-            Problem::ATTRIBUTE_SLUG => [
-                'required',
-                'regex:/^[A-Z0-9]+(?:-[A-Z0-9]+)*$/',
-            ],
-            Problem::ATTRIBUTE_TITLE => 'string|required',
-            Problem::ATTRIBUTE_DESCRIPTION => 'string|required',
+        Problem::ATTRIBUTE_SLUG => [
+            'nullable',
+            'regex:/^[A-Z0-9]+(?:-[A-Z0-9]+)*$/',
         ],
-        UpdateProblemParam::FROM_GRADING => [
-            Problem::ATTRIBUTE_MEMORY_LIMIT => 'numeric|between:0,255|required',
-            Problem::ATTRIBUTE_TIME_LIMIT => 'numeric|between:0,10000|required',
-        ],
+        Problem::ATTRIBUTE_TITLE => 'string|nullable',
+        Problem::ATTRIBUTE_DESCRIPTION => 'string|nullable',
+        Problem::ATTRIBUTE_MEMORY_LIMIT => 'numeric|between:0,255|nullable',
+        Problem::ATTRIBUTE_TIME_LIMIT => 'numeric|between:0,10000|nullable',
     ];
 
     protected $data = [];
-    protected $problem = null;
 
     public function __construct(int $id)
     {
-        $this->problem = Problem::find($id);
         $this->data[Problem::ATTRIBUTE_SLUG] = null;
         $this->data[Problem::ATTRIBUTE_TITLE] = null;
         $this->data[Problem::ATTRIBUTE_DESCRIPTION] = null;
@@ -54,26 +41,32 @@ class UpdateProblemParam
     {
         $this->data[Problem::ATTRIBUTE_SLUG] = isset($array[Problem::ATTRIBUTE_SLUG])
             ? $array[Problem::ATTRIBUTE_SLUG]
-            : $this->problem->slug;
+            : null;
         $this->data[Problem::ATTRIBUTE_TITLE] = isset($array[Problem::ATTRIBUTE_TITLE])
             ?$array[Problem::ATTRIBUTE_TITLE]
-            : $this->problem->title;
+            : null;
         $this->data[Problem::ATTRIBUTE_DESCRIPTION] = isset($array[Problem::ATTRIBUTE_DESCRIPTION])
             ? $array[Problem::ATTRIBUTE_DESCRIPTION]
-            : $this->problem->description;
+            : null;
         $this->data[Problem::ATTRIBUTE_MEMORY_LIMIT] = isset($array[Problem::ATTRIBUTE_MEMORY_LIMIT])
             ? $array[Problem::ATTRIBUTE_MEMORY_LIMIT]
-            : $this->problem->memoty_limit;
+            : null;
         $this->data[Problem::ATTRIBUTE_TIME_LIMIT] = isset($array[Problem::ATTRIBUTE_TIME_LIMIT])
             ? $array[Problem::ATTRIBUTE_TIME_LIMIT]
-            : $this->problem->time_limit;
+            : null;
         $this->data[Problem::ATTRIBUTE_OWNER_ID] = isset($array[Problem::ATTRIBUTE_OWNER_ID])
             ? $array[Problem::ATTRIBUTE_OWNER_ID]
-            : $this->problem->owner_id;
+            : null;
     }
 
     public function toArray(): array
     {
-        return $this->data;
+        $array = [];
+        foreach (self::QUERY_PARAMS as $param){
+            if(isset($this->data[$param])){
+                $array[] = $this->data[$param];
+            }
+        }
+        return $array;
     }
 }

--- a/app/Api/V1/Domain/Problem/Repository/ProblemQueryGenerator.php
+++ b/app/Api/V1/Domain/Problem/Repository/ProblemQueryGenerator.php
@@ -12,6 +12,7 @@ class ProblemQueryGenerator
     {
         $finalQuery = [];
         $finalQuery = $this->buildOwnerIdQuery($finalQuery, $queryParams);
+        $finalQuery = $this->buildIsPublicQuery($finalQuery, $queryParams);
 
         return $finalQuery;
     }
@@ -26,7 +27,7 @@ class ProblemQueryGenerator
 
     public function buildIsPublicQuery(array $query, ReadProblemParam $queryParams): array
     {
-        if ($queryParams->getIsPublic()) {
+        if ($queryParams->getIsPublic() && !$queryParams->getOwnerId()) {
             $query[] = [Problem::ATTRIBUTE_IS_PUBLIC, $queryParams->getIsPublic()];
         }
         return $query;

--- a/app/Api/V1/Domain/Problem/Repository/ProblemQueryGenerator.php
+++ b/app/Api/V1/Domain/Problem/Repository/ProblemQueryGenerator.php
@@ -3,6 +3,7 @@
 namespace App\Api\V1\Domain\Problem\Repository;
 
 
+use App\Api\V1\Domain\Problem\Entity\Problem;
 use App\Api\V1\Domain\Problem\Param\ReadProblemParam;
 
 class ProblemQueryGenerator
@@ -18,7 +19,15 @@ class ProblemQueryGenerator
     public function buildOwnerIdQuery(array $query, ReadProblemParam $queryParams): array
     {
         if ($queryParams->getOwnerId()) {
-            $query[] = ['owner_id', $queryParams->getOwnerId()];
+            $query[] = [Problem::ATTRIBUTE_OWNER_ID, $queryParams->getOwnerId()];
+        }
+        return $query;
+    }
+
+    public function buildIsPublicQuery(array $query, ReadProblemParam $queryParams): array
+    {
+        if ($queryParams->getIsPublic()) {
+            $query[] = [Problem::ATTRIBUTE_IS_PUBLIC, $queryParams->getIsPublic()];
         }
         return $query;
     }

--- a/app/Api/V1/Domain/Problem/Repository/ProblemRepository.php
+++ b/app/Api/V1/Domain/Problem/Repository/ProblemRepository.php
@@ -30,4 +30,14 @@ class ProblemRepository
     {
         return Problem::find($id);
     }
+
+    public function update(int $id, array $data): void
+    {
+        Problem::find($id)->update($data);
+    }
+
+    public function delete(int $id): void
+    {
+        Problem::find($id)->delete();
+    }
 }

--- a/app/Api/V1/Domain/Problem/Services/DeleteProblemService.php
+++ b/app/Api/V1/Domain/Problem/Services/DeleteProblemService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Api\V1\Domain\Problem\Services;
+
+
+use App\Api\V1\Domain\Problem\Repository\ProblemRepository;
+
+class DeleteProblemService
+{
+    protected $repository;
+
+    public function __construct(ProblemRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function delete(int $id): void
+    {
+        $this->repository->delete($id);
+    }
+}

--- a/app/Api/V1/Domain/Problem/Services/UpdateProblemService.php
+++ b/app/Api/V1/Domain/Problem/Services/UpdateProblemService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Api\V1\Domain\Problem\Services;
+
+
+use App\Api\V1\Domain\Problem\Entity\Problem;
+use App\Api\V1\Domain\Problem\Param\UpdateProblemParam;
+use App\Api\V1\Domain\Problem\Repository\ProblemRepository;
+
+class UpdateProblemService
+{
+    protected $repository;
+
+    public function __construct(ProblemRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function update(int $id,UpdateProblemParam $param): void
+    {
+        $this->repository->update($id,$param->toArray());
+    }
+}

--- a/app/Api/V1/Domain/Problem/Services/UpdateProblemService.php
+++ b/app/Api/V1/Domain/Problem/Services/UpdateProblemService.php
@@ -3,7 +3,6 @@
 namespace App\Api\V1\Domain\Problem\Services;
 
 
-use App\Api\V1\Domain\Problem\Entity\Problem;
 use App\Api\V1\Domain\Problem\Param\UpdateProblemParam;
 use App\Api\V1\Domain\Problem\Repository\ProblemRepository;
 
@@ -16,8 +15,8 @@ class UpdateProblemService
         $this->repository = $repository;
     }
 
-    public function update(int $id,UpdateProblemParam $param): void
+    public function update(int $id, UpdateProblemParam $param): void
     {
-        $this->repository->update($id,$param->toArray());
+        $this->repository->update($id, $param->toArray());
     }
 }

--- a/app/Api/V1/Domain/Problem/Transformer/ProblemTransformer.php
+++ b/app/Api/V1/Domain/Problem/Transformer/ProblemTransformer.php
@@ -27,6 +27,7 @@ class ProblemTransformer extends TransformerAbstract
             Problem::ATTRIBUTE_TIME_LIMIT => $problem->getAttribute(Problem::ATTRIBUTE_TIME_LIMIT),
             Problem::ATTRIBUTE_MEMORY_LIMIT => $problem->getAttribute(Problem::ATTRIBUTE_MEMORY_LIMIT),
             Problem::ATTRIBUTE_SLUG => $problem->getAttribute(Problem::ATTRIBUTE_SLUG),
+            Problem::ATTRIBUTE_IS_PUBLIC => $problem->getAttribute(Problem::ATTRIBUTE_IS_PUBLIC),
             'owner' => $owner
         ];
     }

--- a/app/Api/V1/Domain/Submission/Entity/Submission.php
+++ b/app/Api/V1/Domain/Submission/Entity/Submission.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Api\V1\Domain\Submission\Entity;
+
+
+use App\Api\V1\Domain\User\Entity\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Submission extends Model
+{
+    const ATTRIBUTE_ID = 'id';
+    const ATTRIBUTE_USER_ID = 'user_id';
+    const ATTRIBUTE_PROBLEM_ID = 'problem_id';
+    const ATTRIBUTE_CONTEST_ID = 'contest_id';
+    const ATTRIBUTE_LANGUAGE_ID = 'language_id';
+    const ATTRIBUTE_VERDICT = 'verdict';
+    const ATTRIBUTE_FILENAME = 'filename';
+
+    protected $fillable = [
+        self::ATTRIBUTE_USER_ID,
+        self::ATTRIBUTE_PROBLEM_ID,
+        self::ATTRIBUTE_CONTEST_ID,
+        self::ATTRIBUTE_LANGUAGE_ID,
+        self::ATTRIBUTE_VERDICT,
+        self::ATTRIBUTE_FILENAME,
+    ];
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, self::ATTRIBUTE_USER_ID, User::ATTRIBUTE_ID);
+    }
+
+    public function getOwner(): User
+    {
+        return $this->owner;
+    }
+}

--- a/app/Api/V1/Domain/Submission/Param/CreateSubmissionParam.php
+++ b/app/Api/V1/Domain/Submission/Param/CreateSubmissionParam.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ferdinand
+ * Date: 8/25/18
+ * Time: 11:50 AM
+ */
+
+namespace App\Api\V1\Domain\Submission\Param;
+
+
+use App\Api\V1\Domain\Submission\Entity\Submission;
+use Illuminate\Support\Facades\Storage;
+
+class CreateSubmissionParam
+{
+    const SUBMISSION_FILE_PARAM = 'submission_file';
+
+    const QUERY_PARAMS = [
+        Submission::ATTRIBUTE_USER_ID,
+        Submission::ATTRIBUTE_PROBLEM_ID,
+        Submission::ATTRIBUTE_CONTEST_ID,
+        Submission::ATTRIBUTE_LANGUAGE_ID,
+        self::SUBMISSION_FILE_PARAM,
+    ];
+
+    const QUERY_PARAMS_VALIDATION = [
+        Submission::ATTRIBUTE_USER_ID => 'numeric|required',
+        Submission::ATTRIBUTE_PROBLEM_ID => 'numeric|required',
+        Submission::ATTRIBUTE_CONTEST_ID => 'numeric|nullable',
+        Submission::ATTRIBUTE_LANGUAGE_ID => 'numeric|required',
+        self::SUBMISSION_FILE_PARAM => 'file|required',
+    ];
+
+    protected $data = [];
+    protected $submissionFile = null;
+
+    public function __construct()
+    {
+        $this->data[Submission::ATTRIBUTE_USER_ID] = null;
+        $this->data[Submission::ATTRIBUTE_PROBLEM_ID] = null;
+        $this->data[Submission::ATTRIBUTE_CONTEST_ID] = null;
+        $this->data[Submission::ATTRIBUTE_LANGUAGE_ID] = null;
+        $this->data[Submission::ATTRIBUTE_FILENAME] = null;
+    }
+
+    public function fromArray(array $array): void
+    {
+        $this->data[Submission::ATTRIBUTE_USER_ID] = $array[Submission::ATTRIBUTE_USER_ID];
+        $this->data[Submission::ATTRIBUTE_PROBLEM_ID] = $array[Submission::ATTRIBUTE_PROBLEM_ID];
+        $this->data[Submission::ATTRIBUTE_CONTEST_ID] = $array[Submission::ATTRIBUTE_CONTEST_ID];
+        $this->data[Submission::ATTRIBUTE_LANGUAGE_ID] = $array[Submission::ATTRIBUTE_LANGUAGE_ID];
+        $this->submissionFile = $array[self::SUBMISSION_FILE_PARAM];
+    }
+
+    public function saveSubmissionFile(): string
+    {
+        $contestPath = ($this->getContestId() !== null) ? 'contest/' . $this->getContestId() : '';
+
+        $destinationPath = storage_path(
+            $contestPath .
+            '/problem/' . $this->getProblemId()
+        );
+
+        $this->checkDirectory($destinationPath);
+
+        $filename = $this->getUserId() . now()->timestamp . $this->submissionFile->getClientOriginalName();
+
+        Storage::putFileAs(
+            self::SUBMISSION_FILE_PARAM,
+            $this->submissionFile,
+            $filename
+        );
+
+        return $destinationPath . $filename;
+    }
+
+    public function getContestId(): int
+    {
+        return $this->data[Submission::ATTRIBUTE_CONTEST_ID];
+    }
+
+    public function getProblemId(): int
+    {
+        return $this->data[Submission::ATTRIBUTE_PROBLEM_ID];
+    }
+
+    public function checkDirectory(string $path): void
+    {
+        if (is_dir($path)) {
+            Storage::makeDirectory($path);
+        }
+    }
+
+    public function getUserId(): int
+    {
+        return $this->data[Submission::ATTRIBUTE_USER_ID];
+    }
+
+    public function setFilename(string $filename): void
+    {
+        $this->data[Submission::ATTRIBUTE_FILENAME] = $filename;
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/app/Api/V1/Domain/Submission/Repository/SubmissionRepository.php
+++ b/app/Api/V1/Domain/Submission/Repository/SubmissionRepository.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ferdinand
+ * Date: 8/25/18
+ * Time: 11:48 AM
+ */
+
+namespace App\Api\V1\Domain\Submission\Repository;
+
+
+use App\Api\V1\Domain\Submission\Entity\Submission;
+
+class SubmissionRepository
+{
+    public function createOne(array $data): Submission
+    {
+        return Submission::create($data);
+    }
+}

--- a/app/Api/V1/Domain/Submission/Repository/SubmissionRepository.php
+++ b/app/Api/V1/Domain/Submission/Repository/SubmissionRepository.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: ferdinand
- * Date: 8/25/18
- * Time: 11:48 AM
- */
 
 namespace App\Api\V1\Domain\Submission\Repository;
 

--- a/app/Api/V1/Domain/Submission/Services/CreateSubmissionService.php
+++ b/app/Api/V1/Domain/Submission/Services/CreateSubmissionService.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: ferdinand
- * Date: 8/25/18
- * Time: 11:49 AM
- */
 
 namespace App\Api\V1\Domain\Submission\Services;
 
@@ -24,7 +18,7 @@ class CreateSubmissionService
 
     public function createOne(CreateSubmissionParam $param): Submission
     {
-        $filename = $param->saveSubmissionFile();
+        $filename = $param->saveSubmissionCode();
         $param->setFilename($filename);
         return $this->repository->createOne($param->toArray());
     }

--- a/app/Api/V1/Domain/Submission/Services/CreateSubmissionService.php
+++ b/app/Api/V1/Domain/Submission/Services/CreateSubmissionService.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ferdinand
+ * Date: 8/25/18
+ * Time: 11:49 AM
+ */
+
+namespace App\Api\V1\Domain\Submission\Services;
+
+
+use App\Api\V1\Domain\Submission\Entity\Submission;
+use App\Api\V1\Domain\Submission\Param\CreateSubmissionParam;
+use App\Api\V1\Domain\Submission\Repository\SubmissionRepository;
+
+class CreateSubmissionService
+{
+    protected $repository;
+
+    public function __construct(SubmissionRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function createOne(CreateSubmissionParam $param): Submission
+    {
+        $filename = $param->saveSubmissionFile();
+        $param->setFilename($filename);
+        return $this->repository->createOne($param->toArray());
+    }
+}

--- a/database/migrations/2018_07_14_041020_create_problems_table.php
+++ b/database/migrations/2018_07_14_041020_create_problems_table.php
@@ -15,6 +15,7 @@ class CreateProblemsTable extends Migration
             $table->text('description');
             $table->smallInteger('memory_limit');
             $table->integer('time_limit');
+            $table->boolean('is_public');
             $table->unsignedInteger('owner_id');
             $table->timestamps();
 

--- a/database/migrations/2018_07_14_041020_create_problems_table.php
+++ b/database/migrations/2018_07_14_041020_create_problems_table.php
@@ -15,7 +15,7 @@ class CreateProblemsTable extends Migration
             $table->text('description');
             $table->smallInteger('memory_limit');
             $table->integer('time_limit');
-            $table->boolean('is_public');
+            $table->boolean('is_public')->default(false);
             $table->unsignedInteger('owner_id');
             $table->timestamps();
 

--- a/database/migrations/2018_08_25_043559_create_submissions_table.php
+++ b/database/migrations/2018_08_25_043559_create_submissions_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSubmissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('submissions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id')->unsigned();
+            $table->integer('problem_id')->unsigned();
+            $table->integer('contest_id')->default(0);
+            $table->integer('language_id')->unsigned();
+            $table->integer('verdict')->default(0);
+            $table->string('filename');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onUpdate('cascade')->onDelete('cascade');
+
+            $table->foreign('problem_id')
+                ->references('id')->on('problems')
+                ->onUpdate('cascade')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('submissions');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,8 @@ $api->version('v1', function (Router $api) {
             $api->post('/', 'ProblemController@store')->middleware('auth:api');
             $api->get('/','ProblemController@index')->middleware('auth:api');
             $api->get('/{id}','ProblemController@show')->middleware('auth:api');
+            $api->post('/{id}','ProblemController@update')->middleware('auth:api');
+            $api->delete('/{id}','ProblemController@delete')->middleware('auth:api');
         });
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,5 +24,9 @@ $api->version('v1', function (Router $api) {
             $api->post('/{id}','ProblemController@update')->middleware('auth:api');
             $api->delete('/{id}','ProblemController@delete')->middleware('auth:api');
         });
+
+        $api->group(['prefix' => 'submissions'], function (Router $api) {
+            $api->post('/','SubmissionController@store')->middleware('auth:api');
+        });
     });
 });


### PR DESCRIPTION
Add `create` property API for Submission Model,
Submission save in 
`contest/{contest_id}/problem/{problem_id}/[user_id]_[timestamp]_[clientOriginalName].ext` or 
`problem/{problem_id}/[user_id]_[timestamp]_[clientOriginalName].ext`

Field `contest_id` better `nullable` or make default `0` (public/training)

